### PR TITLE
OCP versions with pagination and other improvments

### DIFF
--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -25,7 +25,7 @@ jobs:
         id: read_tests
         run: |
           pip install -r workflows/requirements.txt
-          export AUTH_TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)
+          export GH_AUTH_TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)
           mkdir -p $(dirname ${NEW_VERSION_FILE_PATH})
           echo '{}' > ${NEW_VERSION_FILE_PATH}
           python workflows/update_ocp_version.py workflows/versions.json
@@ -39,12 +39,11 @@ jobs:
           } >> $GITHUB_OUTPUT
 
         env:
-          AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          QUAY_URL_API: "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/"
-          TRACKED_VERSIONS: '["4.12", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20"]'
+          GH_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OCP_TAGS_URL: "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/"
+          OCP_IGNORED_VERSIONS: '["4.11","4.13"]'
           NEW_VERSION_FILE_PATH: "workflows/generatble-files/new_versions.json"
           TEST_TO_TRIGGER_FILE_PATH: "workflows/generatble-files/tests_to_trigger.txt"
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
@@ -52,11 +51,11 @@ jobs:
           commit-message: Update versions
           body: |
             :warning: Before approving the PR, run
-            
+
              ```
             ${{ steps.read_tests.outputs.TEST_TRIGGERS }}
             ```
-            
+
             Updates version of the OCP version
           delete-branch: true
           assignees: empovit,TomerNewman

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -22,8 +22,10 @@
 
 Public, doesn't require authentication, but requires pagination.
 
+Also see https://docs.redhat.com/en/documentation/red_hat_quay/latest/html-single/red_hat_quay_api_guide/index
+
 ```console
-curl -SsL -X GET "https://quay.io/v2/openshift-release-dev/ocp-release/tags/list?n=100&last=4.18.0-x86_64" -H "Content-Type: application/json"
+curl -SsL "https://quay.io/api/v1/repository/openshift-release-dev/ocp-release/tag/?limit=100&page=1&onlyActiveTags=true&filter_tag_name=like:4.1%.%-multi-x86_64" -H "Content-Type: application/json" | jq
 ```
 
 ### NVIDIA GPU operator (releases)

--- a/workflows/settings.py
+++ b/workflows/settings.py
@@ -7,15 +7,15 @@ from typing import Pattern, AnyStr
 class Settings:
     quay_url_api: str
     tag_regex: Pattern[AnyStr]
-    tracked_versions: list[str]
+    ignored_versions: list[str]
     new_version_file_path: str
     tests_to_trigger_file_path: str
 
     def __init__(self):
-        self.quay_url_api = os.getenv("QUAY_URL_API")
+        self.quay_url_api = os.getenv("OCP_TAGS_URL")
+        self.ignored_versions = json.loads(os.getenv("OCP_IGNORED_VERSIONS", "[]"))
         self.new_version_file_path = os.getenv("NEW_VERSION_FILE_PATH")
         self.tests_to_trigger_file_path = os.getenv("TEST_TO_TRIGGER_FILE_PATH")
-        self.tracked_versions = json.loads(os.getenv("TRACKED_VERSIONS", "[]"))
-        self.tag_regex = re.compile(r"^(?P<version>\d+\.\d+\.\d+(?:-ec\.\d+)?)\-x86_64$")
+        self.tag_regex = re.compile(r"^(?P<minor>\d+\.\d+)\.(?P<patch>\d+(?:-rc\.\d+)?)\-multi\-x86_64$")
 
 settings = Settings()

--- a/workflows/update_gpu_bundle.py
+++ b/workflows/update_gpu_bundle.py
@@ -7,11 +7,11 @@ import utils
 
 def get_sha():
 
-    token = os.getenv('AUTH_TOKEN') # In a GitHub workflow, set `AUTH_TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)`
+    token = os.getenv('GH_AUTH_TOKEN') # In a GitHub workflow, set `GH_AUTH_TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)`
     if token:
-        utils.logger.info('AUTH_TOKEN env variable is available, using it for authentication')
+        utils.logger.info('GH_AUTH_TOKEN env variable is available, using it for authentication')
     else:
-        utils.logger.info('AUTH_TOKEN is not available, calling authentication API')
+        utils.logger.info('GH_AUTH_TOKEN is not available, calling authentication API')
         auth_req = requests.get('https://ghcr.io/token?scope=repository:nvidia/gpu-operator:pull', allow_redirects=True,
                                 headers={'Content-Type': 'application/json'})
         auth_req.raise_for_status()


### PR DESCRIPTION
* Use pagination with Quay API.
* Change settings to avoid conflicts with other image streams.
* Leave the list of OCP versions open-ended (allow new minor/major).
* Add ignore list for OCP versions.
* Track RC versions instead of EC.
* Update readme.